### PR TITLE
Fix reset() reference warning in PHP 8.4

### DIFF
--- a/Classes/Service/PlatformAdapter/DTO/TreeProcessor/TreeProcessorResultItem.php
+++ b/Classes/Service/PlatformAdapter/DTO/TreeProcessor/TreeProcessorResultItem.php
@@ -249,6 +249,6 @@ class TreeProcessorResultItem implements TreeProcessorResultItemInterface
      */
     private function flattenLanguageReferences(): array
     {
-        return $this->languageBase?->flattenLanguageReferences() ?? array_map('reset', $this->languageReference);
+        return $this->languageBase?->flattenLanguageReferences() ?? array_map(fn($arr) => reset($arr), $this->languageReference);
     }
 }


### PR DESCRIPTION
Change array_map('reset', ...) to array_map(fn($arr) => reset($arr), ...) to properly handle reference parameter requirement in PHP 8.4.5